### PR TITLE
fix: support vue files

### DIFF
--- a/packages/wrapper-vite/src/plugin/plugin.ts
+++ b/packages/wrapper-vite/src/plugin/plugin.ts
@@ -100,7 +100,6 @@ export function createMacroPlugin(
       return plugin
     },
     name: 'vite-plugin-macro',
-    enforce: 'pre',
     configResolved: async (config) => {
       // create env
       const env = createEnvContext(


### PR DESCRIPTION
This change will allow developers to use `*.vue` files as well because this plugin will run after the transformations.