### PR TITLE
feat: allow passing an `enforce` value

### DIFF
--- a/packages/wrapper-vite/src/plugin/plugin.ts
+++ b/packages/wrapper-vite/src/plugin/plugin.ts
@@ -58,6 +58,14 @@ export type MacroPluginOptions = FilterOptions &
      * @see https://github.com/paulmillr/chokidar#api
      */
     watcherOptions?: WatchOptions
+  
+    /**
+     * Adjust the application order.
+     *
+     * @see https://vitejs.dev/guide/api-plugin.html#plugin-ordering
+     * @default 'pre'
+     */
+    enforce?: 'pre' | 'post' | undefined
   }
 
 /**
@@ -88,6 +96,7 @@ export function createMacroPlugin(
     ssr,
     watcherOptions,
     parserPlugins,
+    enforce,
   } = options
 
   const uninstantiatedProviders: MacroProvider[] = []
@@ -100,7 +109,7 @@ export function createMacroPlugin(
       return plugin
     },
     name: 'vite-plugin-macro',
-    enforce: 'pre',
+    enforce: options.hasOwnProperty('enforce') ? enforce : 'pre',
     configResolved: async (config) => {
       // create env
       const env = createEnvContext(


### PR DESCRIPTION
This PR allows developers to define the `enforce` value so they have more influence of when exactly the macros are applied. For example, for Vue templates it's not possible to use the `pre` enforce mode because the template files needs to be parsed first.